### PR TITLE
Add DuckDuckGo trivia MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ poetry run python app/mcp_servers/poi_discovery/server.py
 
 Leave that running.
 
+
 In a second terminal, start the Inspector for the POI Discovery server:
 
 ```bash
@@ -192,6 +193,25 @@ In a second terminal, start the Inspector for the Wikipedia server:
 
 ```bash
 poetry run mcp dev app/mcp_servers/wikipedia/server.py
+```
+
+---
+
+
+**To run with the Trivia server, use these analogous commands:**
+
+In one terminal, start the **Trivia MCP server**:
+
+```bash
+poetry run python app/mcp_servers/trivia/server.py
+```
+
+Leave that running.
+
+In a second terminal, start the Inspector for the Trivia server:
+
+```bash
+poetry run mcp dev app/mcp_servers/trivia/server.py
 ```
 
 ---

--- a/app/mcp_servers/trivia/Dockerfile
+++ b/app/mcp_servers/trivia/Dockerfile
@@ -1,0 +1,15 @@
+# File: app/mcp_servers/trivia/Dockerfile
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install runtime dependencies using Poetry
+COPY ../../../pyproject.toml /app/
+RUN pip install --no-cache-dir poetry \
+    && poetry config virtualenvs.create false \
+    && poetry install --only main --no-interaction --no-ansi
+
+COPY ../../../app /app/app
+
+CMD ["python", "-m", "app.mcp_servers.trivia.server"]

--- a/app/mcp_servers/trivia/server.py
+++ b/app/mcp_servers/trivia/server.py
@@ -1,0 +1,250 @@
+"""
+Trivia MCP Server: Travel Fact Discovery via DuckDuckGo
+
+This module implements a specialized MCP server that uses the
+DuckDuckGo Instant Answer API to retrieve concise trivia facts for
+travel-related topics. It performs context matching to ensure returned
+facts are relevant to the provided travel context and applies a simple
+source reliability scoring system to filter out low-quality information.
+
+ARCHITECTURAL ROLE:
+-------------------
+The Trivia server functions as an enrichment provider within the
+MCP-orchestrated travel agent system. It supplies interesting facts
+about destinations or landmarks that can be incorporated into travel
+recommendations. The server exposes a single tool `get_trivia` that
+accepts a topic and optional context (e.g., city or country) and returns
+a structured `TriviaResponse`.
+
+DuckDuckGo's Instant Answer API has no official rate limits, but this
+server includes a conservative rate limiter to ensure respectful usage
+when operating in concurrent environments.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, Dict, Optional, Tuple
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# MCP CONFIGURATION AND GLOBALS
+# ---------------------------------------------------------------------------
+
+mcp = FastMCP("Trivia Server")
+logger = logging.getLogger("trivia-server")
+logging.basicConfig(level=logging.INFO)
+
+DUCKDUCKGO_URL = "https://api.duckduckgo.com/"
+HEADERS = {
+    "User-Agent": "MCP-Travel-Agent/1.0 (https://github.com/your-repo)",
+    "Accept": "application/json",
+}
+
+
+# Conservative rate limit: 1 request/second
+
+
+class RateLimiter:
+    """Asynchronous rate limiter to enforce minimum delay between requests."""
+
+    def __init__(self, rate_per_sec: float) -> None:
+        self._interval = 1.0 / rate_per_sec
+        self._lock = asyncio.Lock()
+        self._last_call = 0.0
+
+    async def wait(self) -> None:
+        """Sleep to maintain desired request rate."""
+        async with self._lock:
+            now = time.monotonic()
+            sleep_for = self._last_call + self._interval - now
+            if sleep_for > 0:
+                await asyncio.sleep(sleep_for)
+            self._last_call = time.monotonic()
+
+
+rate_limiter = RateLimiter(rate_per_sec=1)
+
+# ---------------------------------------------------------------------------
+# Pydantic Models
+# ---------------------------------------------------------------------------
+
+
+class TriviaRequest(BaseModel):
+    """Request model for trivia lookups."""
+
+    topic: str = Field(description="Topic to search trivia for")
+    context: Optional[str] = Field(
+        default=None,
+        description="Optional travel context such as a city or country",
+    )
+
+
+class TriviaResponse(BaseModel):
+    """Structured trivia fact and metadata."""
+
+    trivia: str = Field(description="Trivia fact text")
+    source: str = Field(description="Source of the trivia fact")
+    url: Optional[str] = Field(default=None, description="URL to the source")
+    reliability: float = Field(
+        description="Source reliability score between 0 and 1", ge=0.0, le=1.0
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reliability scoring and travel relevance helpers
+# ---------------------------------------------------------------------------
+
+SOURCE_RELIABILITY = {
+    "wikipedia": 0.9,
+    "britannica": 0.8,
+    "duckduckgo": 0.6,
+}
+RELIABILITY_THRESHOLD = 0.6
+TRAVEL_KEYWORDS = {
+    "travel",
+    "tourist",
+    "tourism",
+    "visit",
+    "destination",
+    "city",
+    "country",
+    "landmark",
+    "museum",
+    "beach",
+    "mountain",
+}
+
+
+def score_source(source: str) -> float:
+    """Return reliability score for a source name."""
+
+    return SOURCE_RELIABILITY.get(source.lower(), 0.5)
+
+
+def matches_context(text: str, request: TriviaRequest) -> bool:
+    """Check if a fact matches provided context and travel relevance."""
+
+    text_lower = text.lower()
+    if request.context:
+        context_words = request.context.lower().split()
+        if not any(word in text_lower for word in context_words):
+            return False
+    topic_words = request.topic.lower().split()
+    relevant_keywords = TRAVEL_KEYWORDS.union(topic_words)
+    return any(word in text_lower for word in relevant_keywords)
+
+
+# ---------------------------------------------------------------------------
+# DuckDuckGo API wrapper
+# ---------------------------------------------------------------------------
+
+
+async def fetch_duckduckgo(topic: str, context: Optional[str]) -> Dict[str, Any]:
+    """Query DuckDuckGo Instant Answer API and return JSON data."""
+
+    query = f"{topic} {context}".strip()
+    params = {
+        "q": query,
+        "format": "json",
+        "no_html": 1,
+        "no_redirect": 1,
+    }
+    await rate_limiter.wait()
+    async with httpx.AsyncClient(timeout=10) as client:
+        response = await client.get(DUCKDUCKGO_URL, params=params, headers=HEADERS)
+        response.raise_for_status()
+        return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Fact extraction logic
+# ---------------------------------------------------------------------------
+
+
+def extract_fact(data: Dict[str, Any], request: TriviaRequest) -> Tuple[str, str, str]:
+    """Extract a context-matched fact from DuckDuckGo response."""
+
+    candidates: list[Tuple[str, str, str]] = []
+    # Primary abstract
+    abstract = data.get("AbstractText")
+    if abstract:
+        candidates.append(
+            (
+                abstract,
+                data.get("AbstractSource", "DuckDuckGo"),
+                data.get("AbstractURL", ""),
+            )
+        )
+    # Related topics may contain additional facts
+    for item in data.get("RelatedTopics", []):
+        if isinstance(item, dict):
+            if "Text" in item:
+                candidates.append(
+                    (item["Text"], "DuckDuckGo", item.get("FirstURL", ""))
+                )
+            elif "Topics" in item:
+                for sub in item.get("Topics", []):
+                    if "Text" in sub:
+                        candidates.append(
+                            (sub["Text"], "DuckDuckGo", sub.get("FirstURL", ""))
+                        )
+    for text, source, url in candidates:
+        if matches_context(text, request):
+            return text, source, url
+    return "", "", ""
+
+
+# ---------------------------------------------------------------------------
+# MCP Tool Implementation
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def get_trivia(request: TriviaRequest) -> TriviaResponse:
+    """
+    Fetch travel-related trivia using DuckDuckGo Instant Answer API.
+
+    WORKFLOW:
+    1. Fetch data from DuckDuckGo with rate limiting
+    2. Extract context-matched fact
+    3. Score source reliability and filter low-quality results
+    4. Return structured trivia response
+
+    Raises:
+        RuntimeError: On network errors, missing data, or low-reliability sources
+    """
+
+    try:
+        data = await fetch_duckduckgo(request.topic, request.context)
+    except httpx.TimeoutException as exc:
+        logger.error("DuckDuckGo request timed out: %s", exc)
+        raise RuntimeError("DuckDuckGo request timed out") from exc
+    except httpx.HTTPError as exc:
+        logger.error("DuckDuckGo API error: %s", exc)
+        raise RuntimeError("DuckDuckGo API error") from exc
+
+    fact, source, url = extract_fact(data, request)
+    if not fact:
+        raise RuntimeError("No travel-relevant trivia found")
+
+    reliability = score_source(source)
+    if reliability < RELIABILITY_THRESHOLD:
+        raise RuntimeError("Low reliability source")
+
+    return TriviaResponse(
+        trivia=fact, source=source, url=url or None, reliability=reliability
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")

--- a/tests/integration/test_live_trivia.py
+++ b/tests/integration/test_live_trivia.py
@@ -1,0 +1,113 @@
+"""
+tests/integration/test_live_trivia.py
+-------------------------------------
+
+Live Integration Test + Inspection for the Trivia FastMCP Server
+
+DESCRIPTION
+-----------
+This test connects to your running Trivia MCP server via the
+streamable-HTTP transport, invokes the `get_trivia` tool with a
+real query (e.g., topic "Eiffel Tower", context "Paris"), and:
+
+  • Prints the tool's outputSchema (JSON schema for TriviaResponse)
+  • Prints the raw JSON-RPC content blocks returned
+  • Prints the structuredContent dict
+  • Asserts that trivia, source, and reliability are present
+  • Asserts that the reliability is >= 0.6
+
+PREREQUISITES
+-------------
+1. Your Trivia MCP server must be running:
+     $ poetry run python app/mcp_servers/trivia/server.py
+
+2. You must have network access (calls DuckDuckGo API via MCP server).
+
+HOW TO RUN
+----------
+# To run the test and see only pass/fail:
+$ poetry run pytest tests/integration/test_live_trivia.py
+
+# To also print the schema, raw blocks, and parsed response:
+$ poetry run pytest tests/integration/test_live_trivia.py -s
+
+(The `-s` flag disables pytest’s output capture so you see all print() output.)
+
+EXPECTED BEHAVIOR
+-----------------
+- Without `-s`: You’ll see PASS/FAIL only.
+- With `-s`: The console will show:
+    1. The JSON schema for the get_trivia tool
+    2. The raw JSON-RPC content blocks returned by the server
+    3. The parsed TriviaResponse dict
+- The test passes if the assertions on trivia results hold.
+"""
+
+import pytest
+import json
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_live_get_trivia_inspect():
+    """
+    End-to-end integration test + inspection for 'get_trivia'.
+    """
+    server_url = "http://127.0.0.1:8000/mcp"
+
+    # 1. Establish the streamable-HTTP transport
+    async with streamablehttp_client(server_url) as (read, write, _):
+        # 2. Create an MCP client session over that transport
+        async with ClientSession(read, write) as session:
+            # 3. Perform the initialize handshake
+            await session.initialize()
+
+            # 4. List tools and find our get_trivia tool
+            tools_resp = await session.list_tools()
+            trivia_tool = next(
+                (t for t in tools_resp.tools if t.name == "get_trivia"),
+                None
+            )
+            assert trivia_tool is not None, "get_trivia tool not found"
+
+            # 5. Print the outputSchema (JSON Schema for TriviaResponse)
+            print("\n=== get_trivia outputSchema ===")
+            print(json.dumps(trivia_tool.outputSchema, indent=2))
+
+            # 6. Call the tool with the required 'request' payload
+            req = {
+                "topic": "Eiffel Tower",
+                "context": "Paris"
+            }
+            result = await session.call_tool(
+                "get_trivia",
+                {"request": req}
+            )
+
+            # 7. Print the raw content blocks returned
+            print("\n=== Raw content blocks ===")
+            for block in result.content:
+                try:
+                    print(block.model_dump() if hasattr(block, "model_dump") else block.dict())
+                except Exception:
+                    print(str(block))
+
+    # 8. Print the parsed structuredContent dict
+    data = result.structuredContent
+    print("\n=== parsed TriviaResponse ===")
+    print(json.dumps(data, indent=2, ensure_ascii=False))
+
+    # 9. Validate the structured response or handle error gracefully
+    if data is None:
+        print("No travel-relevant trivia found for the given topic/context. This is expected if the API returns no suitable fact.")
+        # Optionally, assert that the error message is present in the raw content blocks
+        error_msgs = [block.text for block in result.content if hasattr(block, "text") and "Error executing tool" in block.text]
+        assert error_msgs, "Expected an error message in the content blocks when no trivia is found."
+    else:
+        assert isinstance(data, dict), "Expected structuredContent to be a dict"
+        assert "trivia" in data, "Missing 'trivia' in response"
+        assert "source" in data, "Missing 'source' in response"
+        assert "reliability" in data, "Missing 'reliability' in response"
+        assert data["reliability"] >= 0.6, "Reliability below threshold"
+        assert "Eiffel" in data["trivia"] or "Paris" in data["trivia"], "Expected topic/context in trivia fact"

--- a/tests/unit/test_trivia.py
+++ b/tests/unit/test_trivia.py
@@ -1,0 +1,103 @@
+import json
+from typing import Any, Dict
+
+import httpx
+import pytest
+
+from app.mcp_servers.trivia import server
+from app.mcp_servers.trivia.server import TriviaRequest, TriviaResponse
+
+
+class MockResponse(httpx.Response):
+    """Helper to build an httpx.Response with JSON content."""
+
+    def __init__(self, status_code: int, json_data: Dict[str, Any] | None = None):
+        content = json.dumps(json_data or {}).encode()
+        request = httpx.Request("GET", "https://testserver/")
+        super().__init__(status_code, request=request, content=content)
+
+
+@pytest.mark.asyncio
+async def test_trivia_success(monkeypatch):
+    mock_data = {
+        "AbstractText": "The Eiffel Tower in Paris attracts millions of tourists each year.",
+        "AbstractSource": "Wikipedia",
+        "AbstractURL": "https://en.wikipedia.org/wiki/Eiffel_Tower",
+    }
+
+    async def mock_fetch(topic: str, context: str | None) -> Dict[str, Any]:
+        return mock_data
+
+    async def async_noop():
+        pass
+
+    monkeypatch.setattr(server, "fetch_duckduckgo", mock_fetch)
+    monkeypatch.setattr(server.rate_limiter, "wait", async_noop)
+
+    result = await server.get_trivia(
+        TriviaRequest(topic="Eiffel Tower", context="Paris")
+    )
+
+    assert isinstance(result, TriviaResponse)
+    assert "Paris" in result.trivia
+    assert result.source == "Wikipedia"
+    assert result.reliability >= 0.8
+
+
+@pytest.mark.asyncio
+async def test_trivia_low_reliability(monkeypatch):
+    mock_data = {
+        "AbstractText": "The Eiffel Tower in Paris has 1665 steps.",
+        "AbstractSource": "RandomBlog",
+    }
+
+    async def mock_fetch(topic: str, context: str | None) -> Dict[str, Any]:
+        return mock_data
+
+    async def async_noop():
+        pass
+
+    monkeypatch.setattr(server, "fetch_duckduckgo", mock_fetch)
+    monkeypatch.setattr(server.rate_limiter, "wait", async_noop)
+
+    with pytest.raises(RuntimeError, match="Low reliability"):
+        await server.get_trivia(TriviaRequest(topic="Eiffel Tower", context="Paris"))
+
+
+@pytest.mark.asyncio
+async def test_trivia_no_relevant_fact(monkeypatch):
+    mock_data = {
+        "AbstractText": "This fact is unrelated and lacks travel context.",
+        "AbstractSource": "Wikipedia",
+    }
+
+    async def mock_fetch(topic: str, context: str | None) -> Dict[str, Any]:
+        return mock_data
+
+    async def async_noop():
+        pass
+
+    monkeypatch.setattr(server, "fetch_duckduckgo", mock_fetch)
+    monkeypatch.setattr(server.rate_limiter, "wait", async_noop)
+
+    with pytest.raises(RuntimeError, match="No travel-relevant trivia"):
+        await server.get_trivia(TriviaRequest(topic="Eiffel Tower", context="Paris"))
+
+
+@pytest.mark.asyncio
+async def test_trivia_http_error(monkeypatch):
+    async def mock_fetch(topic: str, context: str | None) -> Dict[str, Any]:
+        raise httpx.HTTPStatusError(
+            "error",
+            request=httpx.Request("GET", "https://api.duckduckgo.com"),
+            response=MockResponse(500),
+        )
+
+    async def async_noop():
+        pass
+
+    monkeypatch.setattr(server, "fetch_duckduckgo", mock_fetch)
+    monkeypatch.setattr(server.rate_limiter, "wait", async_noop)
+
+    with pytest.raises(RuntimeError, match="DuckDuckGo API error"):
+        await server.get_trivia(TriviaRequest(topic="Eiffel Tower"))


### PR DESCRIPTION
## Summary
- implement DuckDuckGo-powered Trivia MCP server with context matching and source reliability filtering
- add Pydantic models, FastMCP tool, and Dockerfile for containerized deployment
- cover trivia server with unit tests mocking DuckDuckGo API responses

## Testing
- `PYTHONPATH=. pytest tests/unit/test_trivia.py -q`
- `PYTHONPATH=. pytest tests/unit -q`
- `docker build -t trivia-server -f app/mcp_servers/trivia/Dockerfile .` *(fails: command not found)*
- `python - <<'PY' ...` *(DuckDuckGo API returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f63279d0483298471cd27ac171909