### PR TITLE
Add basic agent orchestrator with FastAPI wrapper and tests

### DIFF
--- a/app/agent/clients.py
+++ b/app/agent/clients.py
@@ -1,0 +1,71 @@
+"""Lightweight MCP client wrappers for the orchestrator.
+
+These classes abstract the connection details to individual MCP servers so that
+`AgentOrchestrator` can remain agnostic of transport specifics. The design
+follows Planning.md §4 which calls for reusable client components.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MCPClient:
+    """Generic MCP client wrapper.
+
+    Attributes:
+        server_url: Base URL of the MCP server (e.g. ``http://localhost:8001/mcp``)
+        tool_name: Name of the MCP tool to invoke on this server
+        timeout:   Per-request timeout in seconds
+    """
+
+    server_url: str
+    tool_name: str
+    timeout: float = 10.0
+
+    async def call(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Invoke the configured MCP tool with the provided payload."""
+        try:
+            async with streamablehttp_client(self.server_url, timeout=self.timeout) as (
+                read,
+                write,
+                _,
+            ):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    result = await session.call_tool(
+                        self.tool_name, {"request": payload}
+                    )
+                    return result.structuredContent or {}
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.error(
+                "tool call failed",
+                extra={"tool": self.tool_name, "url": self.server_url, "error": str(exc)},
+            )
+            raise
+
+    async def health(self) -> bool:
+        """Basic health check by performing an initialize handshake."""
+        try:
+            async with streamablehttp_client(self.server_url, timeout=self.timeout) as (
+                read,
+                write,
+                _,
+            ):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+            return True
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.error(
+                "health check failed",
+                extra={"url": self.server_url, "error": str(exc)},
+            )
+            return False

--- a/app/agent/models.py
+++ b/app/agent/models.py
@@ -1,0 +1,52 @@
+"""Pydantic models for the agent orchestrator.
+
+These models provide a shared contract between the CLI and FastAPI layers.
+They are designed following the architecture in Planning.md §4 and the data
+validation requirements outlined in PRD.md §4.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from pydantic import BaseModel, Field
+
+
+class AgentQuery(BaseModel):
+    """Natural language query issued by a user.
+
+    References:
+        - PRD.md §2 user stories describing free-form queries
+        - Planning.md §4 where the orchestrator sits between user input and MCP tools
+    """
+
+    query: str = Field(..., description="User request to be routed to MCP tools")
+
+
+class ToolResult(BaseModel):
+    """Result returned by an MCP tool.
+
+    Each tool can return arbitrary structured data. The `source` field indicates
+    which MCP server produced the data so callers can reason about downstream
+    handling.
+    """
+
+    source: str = Field(..., description="Name of the MCP server producing the result")
+    data: Any = Field(
+        default_factory=dict,
+        description="Structured content returned by the tool",
+    )
+
+
+class AgentResponse(BaseModel):
+    """Aggregate response from the orchestrator.
+
+    The orchestrator collects results from multiple MCP servers and returns a
+    list of `ToolResult` objects. This mirrors the multi-tool coordination
+    described in Planning.md §4.
+    """
+
+    results: List[ToolResult] = Field(
+        default_factory=list,
+        description="Ordered results from invoked MCP servers",
+    )

--- a/app/agent/orchestrator.py
+++ b/app/agent/orchestrator.py
@@ -1,0 +1,115 @@
+"""Agent orchestration logic coordinating MCP tool calls.
+
+The `AgentOrchestrator` encapsulates the decision flow described in
+Planning.md §4 and implements basic error handling and logging per AGENTS.md.
+The design keeps orchestration independent from the CLI and FastAPI layers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Dict
+
+from .clients import MCPClient
+from .models import AgentQuery, AgentResponse, ToolResult
+
+logger = logging.getLogger(__name__)
+
+
+class AgentOrchestrator:
+    """Coordinate requests across multiple MCP servers."""
+
+    def __init__(self, clients: Dict[str, MCPClient], timeout: float = 10.0):
+        self.clients = clients
+        self.timeout = timeout
+        self.logger = logger
+
+    async def handle_query(self, query: str) -> AgentResponse:
+        """Process a user query by invoking multiple MCP tools.
+
+        Workflow:
+            1. Geocode the query to obtain coordinates (PRD.md §4.1)
+            2. Use coordinates to search for POIs (PRD.md §4.2)
+            3. Fetch Wikipedia info (PRD.md §4.3)
+            4. Retrieve trivia facts (PRD.md §4.4)
+        """
+
+        self.logger.info("handle_query", extra={"query": query})
+        results: list[ToolResult] = []
+
+        try:
+            geocode_data = await asyncio.wait_for(
+                self.clients["geocoding"].call({"location_name": query}),
+                timeout=self.timeout,
+            )
+            results.append(ToolResult(source="geocoding", data=geocode_data))
+        except Exception as exc:  # pragma: no cover - error path
+            self.logger.error("geocoding failed", extra={"error": str(exc)})
+            geocode_data = None
+
+        if geocode_data and {"lat", "lon"} <= geocode_data.keys():
+            try:
+                poi_payload = {
+                    "lat": geocode_data["lat"],
+                    "lon": geocode_data["lon"],
+                }
+                poi_data = await asyncio.wait_for(
+                    self.clients["poi"].call(poi_payload), timeout=self.timeout
+                )
+                results.append(ToolResult(source="poi", data=poi_data))
+            except Exception as exc:  # pragma: no cover - error path
+                self.logger.error("poi search failed", extra={"error": str(exc)})
+
+        # Wikipedia and Trivia run in parallel since they don't depend on each other
+        async def call_optional(name: str, payload: Dict[str, object]):
+            try:
+                data = await asyncio.wait_for(
+                    self.clients[name].call(payload), timeout=self.timeout
+                )
+                results.append(ToolResult(source=name, data=data))
+            except Exception as exc:  # pragma: no cover - error path
+                self.logger.error(
+                    "%s failed", name, extra={"error": str(exc)}
+                )
+
+        await asyncio.gather(
+            call_optional("wikipedia", {"poi_name": query}),
+            call_optional("trivia", {"topic": query}),
+        )
+
+        return AgentResponse(results=results)
+
+
+# ---------------------------------------------------------------------------
+# Factory utilities
+# ---------------------------------------------------------------------------
+
+
+def create_orchestrator() -> AgentOrchestrator:
+    """Create an orchestrator with default MCP clients.
+
+    URLs can be configured via environment variables to support different
+    deployment setups as described in Planning.md §3.
+    """
+
+    clients = {
+        "geocoding": MCPClient(
+            os.getenv("GEOCODING_SERVER_URL", "http://127.0.0.1:8000/mcp"),
+            "geocode_location",
+        ),
+        "poi": MCPClient(
+            os.getenv("POI_SERVER_URL", "http://127.0.0.1:8001/mcp"),
+            "search_pois",
+        ),
+        "wikipedia": MCPClient(
+            os.getenv("WIKIPEDIA_SERVER_URL", "http://127.0.0.1:8002/mcp"),
+            "get_wikipedia_info",
+        ),
+        "trivia": MCPClient(
+            os.getenv("TRIVIA_SERVER_URL", "http://127.0.0.1:8003/mcp"),
+            "get_trivia",
+        ),
+    }
+    return AgentOrchestrator(clients)

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,0 +1,31 @@
+"""Simple CLI entry point for manual agent testing.
+
+This module implements the CLI-first workflow described in Tasks.md Task T006.
+It allows developers to interact with the orchestrator without the FastAPI
+layer, aligning with the "CLI-first" approach in Planning.md §2.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import NoReturn
+
+from .agent.orchestrator import create_orchestrator
+
+
+async def repl() -> NoReturn:
+    """Read–eval–print loop for issuing agent queries from the terminal."""
+
+    orchestrator = create_orchestrator()
+    print("MCP Travel Agent REPL. Type 'quit' to exit.")
+    while True:
+        query = input(">> ").strip()
+        if query.lower() in {"quit", "exit"}:
+            break
+        response = await orchestrator.handle_query(query)
+        print(json.dumps(response.model_dump(), indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    asyncio.run(repl())

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,53 @@
+"""FastAPI wrapper for the agent orchestrator.
+
+Exposes HTTP endpoints for agent queries and health checks as outlined in
+PRD.md §4 and Planning.md §4. CORS configuration supports the React frontend
+from Planning.md §3.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+from .agent.models import AgentQuery, AgentResponse
+from .agent.orchestrator import AgentOrchestrator, create_orchestrator
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="MCP Travel Agent")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+orchestrator: AgentOrchestrator = create_orchestrator()
+
+
+@app.post("/query", response_model=AgentResponse)
+async def query_agent(request: AgentQuery) -> AgentResponse:
+    """Invoke the orchestrator with the supplied query."""
+    try:
+        return await orchestrator.handle_query(request.query)
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.exception("query failed", extra={"error": str(exc)})
+        raise HTTPException(500, detail="Agent processing failed") from exc
+
+
+@app.get("/health/{service}")
+async def health(service: str) -> Dict[str, str]:
+    """Health check for individual MCP servers."""
+    client = orchestrator.clients.get(service)
+    if not client:
+        raise HTTPException(404, detail="unknown service")
+    healthy = await client.health()
+    if not healthy:
+        raise HTTPException(503, detail="unhealthy")
+    return {"status": "ok"}

--- a/tests/integration/test_agent_api.py
+++ b/tests/integration/test_agent_api.py
@@ -1,0 +1,43 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from app import main
+from app.agent.orchestrator import AgentOrchestrator
+
+
+class DummyClient:
+    def __init__(self, data):
+        self.data = data
+
+    async def call(self, payload):
+        return self.data
+
+    async def health(self):
+        return True
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    geo = DummyClient({"lat": 1.0, "lon": 2.0})
+    poi = DummyClient([{"name": "Test"}])
+    wiki = DummyClient({"summary": "info"})
+    trivia = DummyClient({"fact": "fact"})
+    orchestrator = AgentOrchestrator(
+        {"geocoding": geo, "poi": poi, "wikipedia": wiki, "trivia": trivia}
+    )
+    monkeypatch.setattr(main, "orchestrator", orchestrator)
+    return TestClient(main.app)
+
+
+def test_query_endpoint(client):
+    resp = client.post("/query", json={"query": "Rome"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "results" in body
+    assert len(body["results"]) == 4
+
+
+def test_health_endpoint(client):
+    resp = client.get("/health/geocoding")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,0 +1,58 @@
+import pytest
+
+from app.agent.orchestrator import AgentOrchestrator
+from app.agent.models import AgentResponse
+
+
+class DummyClient:
+    def __init__(self, data, fail: bool = False):
+        self.data = data
+        self.fail = fail
+        self.last_payload = None
+
+    async def call(self, payload):
+        self.last_payload = payload
+        if self.fail:
+            raise RuntimeError("boom")
+        return self.data
+
+    async def health(self):  # pragma: no cover - not used here
+        return True
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_happy_path():
+    geo = DummyClient({"lat": 1.0, "lon": 2.0})
+    poi = DummyClient([{"name": "Test"}])
+    wiki = DummyClient({"summary": "info"})
+    trivia = DummyClient({"fact": "fact"})
+    orchestrator = AgentOrchestrator(
+        {"geocoding": geo, "poi": poi, "wikipedia": wiki, "trivia": trivia}
+    )
+
+    resp = await orchestrator.handle_query("Rome")
+    assert isinstance(resp, AgentResponse)
+    assert poi.last_payload == {"lat": 1.0, "lon": 2.0}
+    assert {r.source for r in resp.results} == {
+        "geocoding",
+        "poi",
+        "wikipedia",
+        "trivia",
+    }
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_geocode_failure():
+    geo = DummyClient({}, fail=True)
+    poi = DummyClient([])
+    wiki = DummyClient({"summary": "info"})
+    trivia = DummyClient({"fact": "fact"})
+    orchestrator = AgentOrchestrator(
+        {"geocoding": geo, "poi": poi, "wikipedia": wiki, "trivia": trivia}
+    )
+
+    resp = await orchestrator.handle_query("Nowhere")
+    sources = {r.source for r in resp.results}
+    assert "geocoding" not in sources  # failed geocode skipped
+    assert "poi" not in sources  # POI not called due to missing coords
+    assert "wikipedia" in sources and "trivia" in sources


### PR DESCRIPTION
## Summary
- build MCP client abstractions and core AgentOrchestrator
- expose CLI and FastAPI interfaces with health checks and CORS
- add orchestration unit tests and FastAPI integration test

## Testing
- `PYTHONPATH=. pytest tests/unit/test_orchestrator.py tests/integration/test_agent_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689068ca822883299128416d8e378d36